### PR TITLE
update ievms.sh

### DIFF
--- a/ievms.sh
+++ b/ievms.sh
@@ -468,7 +468,7 @@ fi
 		"echo start /wait msiexec /i C:\webpagetest\7z.msi /quiet /q INSTALLDIR=C:\7zip >>c:\\webpagetest\\wpt.bat"
 	log "Unzip wpt agent"
 	guest_control_exec "${1}" "cmd.exe" /c \
-		"echo c:\7zip\7z.exe x c:\webpagetest\webpagetest_${WPT_VERSION}.zip -y -oc:\webpagetest agent/* >>c:\\webpagetest\\wpt.bat"
+		"echo start /wait c:\7zip\7z.exe x c:\webpagetest\webpagetest_${WPT_VERSION}.zip -y -oc:\webpagetest agent/* >>c:\\webpagetest\\wpt.bat"
 	log "Installing winpcap"
 	guest_control_exec "${1}" "cmd.exe" /c \
 		"echo start /wait c:\webpagetest\agent\winpcap-nmap-4.12.exe /S >> c:\\webpagetest\\wpt.bat"
@@ -540,7 +540,7 @@ fi
 		guest_control_exec "${1}" "cmd.exe" /c \
 			"c:\\webpagetest\\certutil –addstore –f TrustedPublisher c:\\webpagetest\\WPOFoundation.cer "
 		guest_control_exec "${1}" "cmd.exe" /c \
-			"c:\\webpagetest\\mindinst.exe c:\\webpagetest\\agent\\dummynet\\32bit\\netipfw.inf -i -s "
+			"c:\\webpagetest\\mindinst.exe c:\\webpagetest\\agent\\dummynet\\64bit\\netipfw.inf -i -s "
 		guest_control_exec "${1}" "cmd.exe" /c \
         		"shutdown.exe /s /f /t 0"
         	wait_for_guestcontrol "${1}"
@@ -554,22 +554,21 @@ fi
                 "echo start /wait %windir%\System32\reg.exe ADD HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System /v EnableLUA /t REG_DWORD /d 0 /f >>c:\webpagetest\wpt.bat"
                 log "Disable driver installation integrity checks"
                 guest_control_exec "${1}" "cmd.exe" /c \
-                        "echo start bcdedit.exe -set nointegritychecks ON >>c:\\webpagetest\\wpt.bat"
+                        "echo start /wait  bcdedit.exe -set nointegritychecks ON >>c:\\webpagetest\\wpt.bat"
                 guest_control_exec "${1}" "cmd.exe" /c \
-                        "echo startbcdedit.exe -set TESTSIGNING ON >>c:\\webpagetest\\wpt.bat"
+                        "echo start /wait bcdedit.exe -set TESTSIGNING ON >>c:\\webpagetest\\wpt.bat"
                 guest_control_exec "${1}" "cmd.exe" /c \
-                        "echo startbcdedit /set {default} bootstatuspolicy ignoreallfailures >>c:\\webpagetest\\wpt.bat"
+                        "echo start /wait bcdedit /set {default} bootstatuspolicy ignoreallfailures >>c:\\webpagetest\\wpt.bat"
 		guest_control_exec "${1}" "cmd.exe" /c \
-			"echo start Certutil –addstore –f TrustedPublisher c:\\webpagetest\\WPOFoundation.cer >>c:\\webpagetest\\wpt.bat"
+			"echo start /wait Certutil –addstore –f TrustedPublisher c:\\webpagetest\\WPOFoundation.cer >>c:\\webpagetest\\wpt.bat"
 		guest_control_exec "${1}" "cmd.exe" /c \
-			"echo start  c:\\webpagetest\\mindinst.exe c:\\webpagetest\\agent\\dummynet\\netipfw.inf -i -s >>c:\\webpagetest\\wpt.bat"
+			"echo start /wait  c:\\webpagetest\\mindinst.exe c:\\webpagetest\\agent\\dummynet\\netipfw.inf -i -s >>c:\\webpagetest\\wpt.bat"
 		guest_control_exec "${1}" "cmd.exe" /c \
-			"echo shutdown.exe /s /f /t 0 >>C:\\Users\\${guest_user}\\wpt.bat"
-		guest_control_exec "${1}" "cmd.exe" /c \
-			             "copy c:\webpagetest\wpt.bat C:\Users\\${guest_user}\\ievms.bat"
-                guest_control_exec "${1}" "schtasks.exe" /run /tn ievms
-
-    		wait_for_guestcontrol "${1}"
+			"echo shutdown.exe /s /f /t 0 >>C:\\webpagetest\\wpt.bat"
+                guest_control_exec "${1}" "cmd.exe" /c \
+			"copy c:\\webpagetest\\wpt.bat C:\Users\\${guest_user}\\ievms.bat"
+		guest_control_exec "${1}" "schtasks.exe" /run /tn ievms
+        	wait_for_shutdown "${1}"
 
 	fi
 	
@@ -611,17 +610,21 @@ fi
 			"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Active Setup\Installed Components\{A509B1A8-37EF-4b3f-8CFC-4F3A74704073}" \
 			/f /va
 	fi
+
 }
 
 # Install an alternative version of IE in an XP virtual machine. Downloads the
 # installer, copies it to the vm, then runs it before shutting down.
+
 install_ie_xp() { # vm url md5
     local src=`basename "${2}"`
     local dest="C:\\Documents and Settings\\${guest_user}\\Desktop\\${src}"
 
     download "${src}" "${2}" "${src}" "${3}"
     copy_to_vm "${1}" "${src}" "${dest}"
-
+    log "Installing IE"
+    guest_control_exec "${1}" "cmd.exe" /c \
+        "echo ${dest} /passive /norestart >C:\\Users\\${guest_user}\\wpt.bat"
     log "Installing IE" # Always "fails"
     guest_control_exec "${1}" "${dest}" /passive /norestart || true
 
@@ -638,17 +641,12 @@ install_ie_win7() { # vm url md5
     start_vm "${1}"
     wait_for_guestcontrol "${1}"
     copy_to_vm "${1}" "${src}" "${dest}"
-
     log "Installing IE"
     guest_control_exec "${1}" "cmd.exe" /c \
-        "echo ${dest} /passive /norestart >C:\\Users\\${guest_user}\\wpt.bat"
+    "echo start /wait ${dest} /passive /norestart >C:\\Users\\${guest_user}\\ievms.bat"
     guest_control_exec "${1}" "cmd.exe" /c \
-        "echo shutdown.exe /s /f /t 0 >>C:\\Users\\${guest_user}\\wpt.bat"
+    "echo shutdown.exe /s /f /t 0 >>C:\\Users\\${guest_user}\\ievms.bat"
     guest_control_exec "${1}" "schtasks.exe" /run /tn ievms
-
-    wait_for_guestcontrol "${1}"
-
-    guest_control_exec "${1}" "shutdown.exe" /s /f /t 0
     wait_for_shutdown "${1}"
 
 }
@@ -664,17 +662,12 @@ install_ie_win2k8() { # vm url md5
     start_vm "${1}"
     wait_for_guestcontrol "${1}"
     copy_to_vm "${1}" "${src}" "${dest}"
-
     log "Installing IE"
     guest_control_exec "${1}" "cmd.exe" /c \
-        "echo ${dest} /passive /norestart >C:\\Users\\${guest_user}\\wpt.bat"
+    "echo start /wait ${dest} /passive /norestart >C:\\Users\\${guest_user}\\ievms.bat"
     guest_control_exec "${1}" "cmd.exe" /c \
-        "echo shutdown.exe /s /f /t 0 >>C:\\Users\\${guest_user}\\wpt.bat"
+    "echo shutdown.exe /s /f /t 0 >>C:\\Users\\${guest_user}\\ievms.bat"
     guest_control_exec "${1}" "schtasks.exe" /run /tn ievms
-
-    wait_for_guestcontrol "${1}"
-
-    guest_control_exec "${1}" "shutdown.exe" /s /f /t 0
     wait_for_shutdown "${1}"
 }
 
@@ -697,27 +690,23 @@ build_ievm() {
                 unit="10"
             fi
             ;;
-        9) os="Win7" ;;
-        10|11)
-            if [ "${reuse_win7}" != "yes" ]
-            then if [ "$1" == "11" ]; then fail "IE11 is only available if REUSE_WIN7 is set"; fi
-                os="Win2k8"
- 	else
-                os="Win7"
-                archive="IE9_Win7.zip"
-            fi
-	    ;;
-	    
-	9) os="Win2k8" ;;
-	10|11)
-	     if [ "${reuse_win2k8}" != "yes" ]
-		then if [ "$1" == "11" ]; then fail "IE11 is only avaiblable if REUSE_WIN2K8 is set"; fi
-                   os="Win8"
-	else
-		  os="Win2k8"
-		  archive="IE9_Win2k8.zip"
-	     fi
-	     ;;
+
+	9) os="Win7" ;; 
+          10|11)
+		  if [ "${reuse_win7}" == "yes" ]
+			then
+ 		        os="Win7"
+            		archive="IE9_Win7.zip"
+		  elif [ "{reuser_win2k8}" == "yes"]
+	    		then
+			os="Win2k8"
+	    		archive="IE9_Win2k8.zip"
+		 else
+			os="Win8"
+
+	         fi
+	         ;;
+
 	EDGE)
             prefix="MS"
             version="Edge"
@@ -745,11 +734,9 @@ build_ievm() {
     case $archive in
         IE6_WinXP.zip) md5="3d5b7d980296d048de008d28305ca224" ;;
         IE7_Vista.zip) md5="d5269b2220f5c7fb9786dad513f2c05a" ;;
-        #IE8_Win2k8.zip) md5="9e491948286ed3015f695cb49c939776" ;;
 	IE8_Win7.zip) md5="21b0aad3d66dac7f88635aa2318a3a55" ;;
         IE9_Win7.zip) md5="58d201fe7dc7e890ad645412264f2a2c" ;;
-        IE9_Win2k8.zip) md5="a69086febf216cb8452495f1aeb64d5e" ;;
-	IE10_Win2k8.zip) md5="8c8620cb1ee4c4ce17f6f2d95d5fff56" ;;
+        IE9_Win2k8.zip) md5="4850fcb5b4674370e98a14e1bab39368" ;;
 	IE10_Win8.zip) md5="cc4e2f4b195e1b1e24e2ce6c7a6f149c" ;;
         MSEdge_Win10.zip) md5="c1011b491d49539975fb4c3eeff16dae" ;;
     esac
@@ -782,16 +769,11 @@ build_ievm() {
 
         log "Creating clean snapshot"
         VBoxManage snapshot "${vm}" take clean --description "The initial VM state"
-	#sleep 200
-
-# Shutdown the Vm to finish installation
-	sleep 200
-	log "Shutting down vm"
-        guest_control_exec "${vm}" "shutdown.exe" /s /f /t 0
-        wait_for_shutdown "${vm}"
-
-        log "restart the vm "
-        start_vm "${vm}"
+	
+# Start the Vm to finish installation
+	
+         log "restart the vm "
+         start_vm "${vm}"
 fi
 }
 
@@ -819,10 +801,10 @@ build_ievm_ie8() {
     if [ "${reuse_xp}" != "yes" ]
     then
         boot_auto_ga "IE8 - Win7"
-                install_wpt_agent "IE8 - Win7" "${WPT_FILENAME}" "${os}"
+        install_wpt_agent "IE8 - Win7" "${WPT_FILENAME}" "${os}"
 else
         set_xp_password "IE8 - WinXP"
-		install_wpt_agent "IE8 - WinXP" "${WPT_FILENAME}" "${os}"
+	install_wpt_agent "IE8 - WinXP" "${WPT_FILENAME}" "${os}"
         install_ie_xp "IE8 - WinXP" "http://download.microsoft.com/download/C/C/0/CC0BD555-33DD-411E-936B-73AC6F95AE11/IE8-WindowsXP-x86-ENU.exe" "616c2e8b12aaa349cd3acb38bf581700"
     fi
 }
@@ -845,14 +827,14 @@ build_ievm_ie10() {
     if [ "${reuse_win7}" != "yes" ]
     then
         boot_auto_ga "IE10 - Win2k8"
-	install_ie_win2k8  "IE10 - Win2k8" "http://download.microsoft.com/download/C/E/0/CE0AB8AE-E6B7-43F7-9290-F8EB0EA54FB5/IE10-Windows6.1-x64-en-us.exe" "7ca1f1f4ab4e9599e2fa79d2684562da"
 	install_wpt_agent "IE10 - Win2k8" "${WPT_FILENAME}" "${os}"
+	install_ie_win2k8 "IE10 - Win2k8" "http://download.microsoft.com/download/C/E/0/CE0AB8AE-E6B7-43F7-9290-F8EB0EA54FB5/IE10-Windows6.1-x64-en-us.exe" "7ca1f1f4ab4e9599e2fa79d2684562da"
 
     else
  
         boot_auto_ga "IE10 - Win7"
-        install_ie_win7 "IE10 - Win7" "http://download.microsoft.com/download/8/A/C/8AC7C482-BC74-492E-B978-7ED04900CEDE/IE10-Windows6.1-x86-en-us.exe" "0f14b2de0b3cef611b9c1424049e996b"
 	install_wpt_agent "IE10 - Win7" "${WPT_FILENAME}" "${os}"
+        install_ie_win7 "IE10 - Win7" "http://download.microsoft.com/download/8/A/C/8AC7C482-BC74-492E-B978-7ED04900CEDE/IE10-Windows6.1-x86-en-us.exe" "0f14b2de0b3cef611b9c1424049e996b"
 
     fi
 }
@@ -864,11 +846,13 @@ build_ievm_ie11() {
 	boot_auto_ga "IE11 - Win2k8"
 	install_wpt_agent "IE11 -Win2k8" "${WPT_FILENAME}" "${os}"
 	install_ie_win2k8 "IE11 - Win2k8" "https://download.microsoft.com/download/7/1/7/7179A150-F2D2-4502-9D70-4B59EA148EAA/IE11-Windows6.1-x64-en-us.exe" "839a1a4d5043d694cd324c33937e00ae"
-    else
+
+   else
     	boot_auto_ga "IE11 - Win7"
 	install_wpt_agent "IE11 - Win7" "${WPT_FILENAME}" "${os}"
-        install_ie_win7 "IE11 - Win7" "http://download.microsoft.com/download/9/2/F/92FC119C-3BCD-476C-B425-038A39625558/IE11-Windows6.1-x86-en-us.exe" "7d3479b9007f3c0670940c1b10a3615f"
-    fi
+	install_ie_win7 "IE11 - Win7" "http://download.microsoft.com/download/9/2/F/92FC119C-3BCD-476C-B425-038A39625558/IE11-Windows6.1-x86-en-us.exe" "7d3479b9007f3c0670940c1b10a3615f"
+
+ fi
 }
 
 ## ## Main Entry Point

--- a/ievms.sh
+++ b/ievms.sh
@@ -1,4 +1,4 @@
-*#!/usr/bin/env bash
+#!/usr/bin/env bash
 
 export PATH=$PATH:/usr/local/bin/
 

--- a/ievms.sh
+++ b/ievms.sh
@@ -720,22 +720,6 @@ build_ievm() {
 			archive="IE8_Win7.zip"
 	         fi
 	         ;;
-
-
-
-
-#	case $1 in
-#	8|9|10|11)
-#		os="Win2k8" ;;
-#		if [ "${reuse_win2k8}" != "yes" }
-#			then
-#			os="Win7"
-#			archive="IE8_Win7.zip"
-#		else
-#			os="Win2k8"
-#			archive="IE8_Win2k8.zip"
-#		fi
-#		;;
 	   EDGE)
             prefix="MS"
             version="Edge"
@@ -836,13 +820,7 @@ else
     	boot_auto_ga "IE8 - Win7"
         install_wpt_agent "IE8 - Win7" "${WPT_FILENAME}" "${os}"
 
-#else   os="WinXP"
-#	set_xp_password "IE8 - WinXP"
-#        install_wpt_agent "IE8 - WinXP" "${WPT_FILENAME}" "${os}"
-#        install_ie_xp "IE8 - WinXP" "http://download.microsoft.com/download/C/C/0/CC0BD555-33DD-411E-936B-73AC6F95AE11/IE8-WindowsXP-x86-ENU.exe" "616c2e8b12aaa349cd3acb38bf581700"
-
-
-   fi
+    fi
 }
 
 # Build the IE9 virtual machine 


### PR DESCRIPTION
Working on both Win2k8 and Win7

ipfw driver install properly with 64bits dummy folder's files (both for Win7 32bits and 64bits operating system)

required visual c++ 2008 x86 ( not 64 bits) to work properly

Firefox_41 must be include on based image  

Firefox compatible with version 41 and earlier with webpagetest, auto update disabled : 
auto install  via webpagetest configuration or by silent mode isn't working fine: firefox can't stop auto update after installing it and jump to latest firefox version. 
